### PR TITLE
Adds Python 3.13 and 3.14 Support

### DIFF
--- a/.github/workflows/build-test-python-package.yml
+++ b/.github/workflows/build-test-python-package.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: true 
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 license = "MIT"
 license-files = ["LICENSE.txt"]


### PR DESCRIPTION
- [ ] closes issue #44
- [ ] tests added / passed `pytest .`
- [ ] passes `black .`
- [ ] passes `git diff upstream/develop -u -- "*.py" | flake8 --diff`
- [ ] what's new
  - Updates the CI workflow to build and test the package against Python 3.13 and 3.14, ensuring continued compatibility with newer versions.
  - Declares official support for Python 3.13 and 3.14 by adding them to the `classifiers` in `pyproject.toml`.
  - Ensures continuous integration and project metadata reflect support for the latest Python releases.