### PR TITLE
Fixes concatenate method return

### DIFF
--- a/spinlab/core/base.py
+++ b/spinlab/core/base.py
@@ -1016,6 +1016,8 @@ class ABCData(object):
             )
         )
 
+        return self
+
     def new_dim(self, dim, coord):
         """Add new dimension with length 1
 


### PR DESCRIPTION
- [ ] closes issue #xxxx
- [ ] tests added / passed `pytest .`
- [ ] passes `black .`
- [ ] passes `git diff upstream/develop -u -- "*.py" | flake8 --diff`
- [x] what's new

Ensures the `concatenate` method explicitly returns the `self` instance. Previously, the method implicitly returned `None`, which could lead to unexpected behavior and break method chaining.