### PR TITLE
Adds SpecLog CSV data support

### DIFF
--- a/spinlab/config/spinlab.cfg
+++ b/spinlab/config/spinlab.cfg
@@ -147,6 +147,19 @@ ax.set_title= Saturation Recovery
 __marker = o
 __fillstyle = none
 
+[FANCY_PLOT:SpecLog]
+
+dim = time
+ax.set_xlabel = Time, fontsize = 14
+ax.set_ylabel = Value, fontsize = 14
+ax.set_title = SpecLog
+legend_loc = lower center
+legend_bbox_x = 0.5
+legend_bbox_y = 0.01
+legend_ncol = 3
+legend_margin_base = 0.08
+legend_margin_per_row = 0.055
+
 [FANCY_PLOT:sl_enhancement_profile_f]
 
 ax.set_xlabel= Frequency [GHz], fontsize = 14

--- a/spinlab/core/base.py
+++ b/spinlab/core/base.py
@@ -282,6 +282,12 @@ class ABCData(object):
 
             data['x', 4.5] # return data indexing down "x" dim with "x" coords nearest to 4.5
 
+            data['time', '2025-01-16T00:00:06'] # nearest value on a datetime coordinate
+
+            data['channel', 'signal'] # exact value on a string coordinate
+
+            data['channel', ['signal', 'reference']] # multiple named coordinates
+
             data['x', 2:5] # return data indexing down "x" dim with index from 2 to 5
 
             data['x', (100., 150.)] # return data indexing down "x" dim where coords are range from 100 to 150
@@ -297,10 +303,57 @@ class ABCData(object):
 
         index_slice = args[1::2]
 
+        # Convert ISO timestamp strings when indexing datetime coordinates.
+        converted_index_slice = []
+        for dim, slice_ in zip(index_dims, index_slice):
+            coord = a.get_coord(dim)
+            if _np.issubdtype(coord.dtype, _np.datetime64):
+                if isinstance(slice_, str):
+                    try:
+                        slice_ = _np.datetime64(slice_)
+                    except ValueError as exc:
+                        raise ValueError(
+                            f"Invalid datetime selector for dimension {dim!r}: {slice_!r}"
+                        ) from exc
+                elif isinstance(slice_, tuple):
+                    try:
+                        slice_ = tuple(
+                            _np.datetime64(value) if isinstance(value, str) else value
+                            for value in slice_
+                        )
+                    except ValueError as exc:
+                        raise ValueError(
+                            f"Invalid datetime selector for dimension {dim!r}: {slice_!r}"
+                        ) from exc
+            elif isinstance(slice_, str):
+                matches = _np.flatnonzero(coord == slice_)
+                if matches.size == 0:
+                    raise KeyError(
+                        f"Coordinate {slice_!r} not found in dimension {dim!r}"
+                    )
+                slice_ = int(matches[0])
+            elif isinstance(slice_, (list, _np.ndarray)) and all(
+                isinstance(value, str) for value in slice_
+            ):
+                indices = []
+                for value in slice_:
+                    matches = _np.flatnonzero(coord == value)
+                    if matches.size == 0:
+                        raise KeyError(
+                            f"Coordinate {value!r} not found in dimension {dim!r}"
+                        )
+                    indices.append(int(matches[0]))
+                slice_ = _np.asarray(indices, dtype=int)
+            converted_index_slice.append(slice_)
+        index_slice = converted_index_slice
+
         # check slices
         for slice_ in index_slice:
             # type must be slice or tuple
-            if not isinstance(slice_, (slice, tuple, float, int)):
+            if not isinstance(
+                slice_,
+                (slice, tuple, list, _np.ndarray, float, int, _np.datetime64),
+            ):
                 raise ValueError("Invalid slice type")
 
             # if tuple, length must be two: (start, stop)
@@ -332,7 +385,7 @@ class ABCData(object):
                     updated_index_slice.append(slice(start, start + 1))
                 else:
                     updated_index_slice.append(slice(slice_, None))
-            elif isinstance(slice_, float):
+            elif isinstance(slice_, (float, _np.datetime64)):
                 start = _np.argmin(_np.abs(slice_ - a.get_coord(dim)))
                 updated_index_slice.append(slice(start, start + 1))
             else:

--- a/spinlab/io/__init__.py
+++ b/spinlab/io/__init__.py
@@ -14,6 +14,7 @@ from . import vna
 from . import tnmr
 from . import random
 from . import load_csv
+from . import speclog
 from . import rs2d
 from . import mat
 from . import logs

--- a/spinlab/io/load.py
+++ b/spinlab/io/load.py
@@ -34,6 +34,10 @@ def load(path, data_format=None, dim=None, coord=[], verbose=False, *args, **kwa
     """
 
     if isinstance(path, list):
+        detected_format = data_format or autodetect(path[0], verbose=verbose)
+        if detected_format.lower() == "speclog":
+            return speclog.load_speclog(path, *args, **kwargs)
+
         if len(coord) != len(path):
             raise ValueError(
                 "coord must be a list or array equal in len to the number of paths given"
@@ -44,16 +48,18 @@ def load(path, data_format=None, dim=None, coord=[], verbose=False, *args, **kwa
             dim = "unnamed"
         for filename in path:
             data = load_file(
-                filename, data_format=data_format, verbose=verbose, *args, **kwargs
+                filename,
+                data_format=detected_format,
+                verbose=verbose,
+                *args,
+                **kwargs,
             )
             data_list.append(data)
         # coord could be empty list
         if len(coord) == 0:
             coord = None  # to not break concat call signature
 
-        data = concat(data_list, dim=dim, coord=coord)
-
-        return data
+        return concat(data_list, dim=dim, coord=coord)
 
     else:
         return load_file(
@@ -128,10 +134,24 @@ def load_file(path, data_format=None, verbose=False, *args, **kwargs):
     # elif data_format == "mat":
     #     data = mat.import_mat(path, *args, **kwargs)
 
+    elif data_format == "csv":
+        data = load_csv.load_csv(path, *args, **kwargs)
+
+    elif data_format == "speclog":
+        data = speclog.load_speclog(path, *args, **kwargs)
+
     else:
         raise ValueError("Invalid data format: %s" % data_format)
 
-    if data_format not in ["h5", "power", "vna", "cnsi_powers", "mat"]:
+    if data_format.lower() not in [
+        "h5",
+        "power",
+        "vna",
+        "cnsi_powers",
+        "mat",
+        "csv",
+        "speclog",
+    ]:
         data = _assign_spinlab_attrs(data, data_format)
 
     return data
@@ -204,6 +224,11 @@ def autodetect(test_path, verbose=False):
         data_format = "rs2d"
     elif path_exten in [".mat"]:
         data_format = "mat"
+    elif path_exten.lower() == ".csv":
+        if os.path.basename(test_path).lower().startswith("log_"):
+            data_format = "speclog"
+        else:
+            data_format = "csv"
     else:
         raise TypeError(
             "No data format given and autodetect failed to detect format, please specify a format"

--- a/spinlab/io/speclog.py
+++ b/spinlab/io/speclog.py
@@ -1,0 +1,143 @@
+"""Import SpecLog CSV files."""
+
+import csv
+import os
+from datetime import datetime
+
+import numpy as _np
+
+from ..core.data import SpinData
+
+
+def load_speclog(filename, delimiter=",", encoding="utf-8-sig"):
+    """Load a SpecLog CSV file as a two-dimensional :class:`SpinData`.
+
+    SpecLog files contain ``Date`` and ``Time`` columns followed by one or
+    more numeric instrument channels.  The returned data has dimensions
+    ``time`` and ``channel``.  Its time coordinate uses NumPy
+    ``datetime64[us]`` values and its channel coordinate contains the column
+    names from the file.
+
+    Args:
+        filename (str, path-like, or list): SpecLog CSV file to read, or a
+            list of files to merge and sort by time.
+        delimiter (str): CSV field delimiter. Defaults to ``,``.
+        encoding (str): Text encoding. Defaults to ``utf-8-sig`` so files
+            with or without a UTF-8 byte-order mark are accepted.
+
+    Returns:
+        SpinData: Numeric log values with shape ``(n_times, n_channels)``.
+
+    Raises:
+        ValueError: If the header, a timestamp, a row width, or a numeric
+            value is invalid. Empty numeric cells are represented by NaN.
+    """
+    if isinstance(filename, (list, tuple)):
+        if not filename:
+            raise ValueError("At least one SpecLog file is required")
+
+        datasets = [
+            load_speclog(path, delimiter=delimiter, encoding=encoding)
+            for path in filename
+        ]
+        channels = datasets[0].coords["channel"]
+        channel_set = set(channels.tolist())
+        aligned_values = []
+        for path, dataset in zip(filename, datasets):
+            file_channels = dataset.coords["channel"]
+            if set(file_channels.tolist()) != channel_set:
+                raise ValueError(
+                    f"SpecLog channels in {os.fspath(path)!r} do not match "
+                    "the first file"
+                )
+            indices = [
+                int(_np.flatnonzero(file_channels == channel)[0])
+                for channel in channels
+            ]
+            aligned_values.append(dataset.values[:, indices])
+
+        values = _np.concatenate(aligned_values, axis=0)
+        time_coord = _np.concatenate([dataset.coords["time"] for dataset in datasets])
+        order = _np.argsort(time_coord, kind="stable")
+        attrs = {
+            "source_files": [os.path.abspath(os.fspath(path)) for path in filename],
+            "experiment_type": "SpecLog",
+        }
+        return SpinData(
+            values[order],
+            dims=["time", "channel"],
+            coords=[time_coord[order], channels.copy()],
+            attrs=attrs,
+        )
+
+    filename = os.fspath(filename)
+
+    with open(filename, "r", newline="", encoding=encoding) as csv_file:
+        reader = csv.reader(csv_file, delimiter=delimiter, skipinitialspace=True)
+        try:
+            header = [field.strip() for field in next(reader)]
+        except StopIteration as exc:
+            raise ValueError("SpecLog file is empty") from exc
+
+        if len(header) < 3 or [name.lower() for name in header[:2]] != [
+            "date",
+            "time",
+        ]:
+            raise ValueError(
+                "SpecLog header must start with 'Date, Time' and contain "
+                "at least one data channel"
+            )
+
+        channels = header[2:]
+        if any(not channel for channel in channels):
+            raise ValueError("SpecLog channel names must not be empty")
+
+        timestamps = []
+        rows = []
+        for line_number, row in enumerate(reader, start=2):
+            if not row or all(not field.strip() for field in row):
+                continue
+            if len(row) != len(header):
+                raise ValueError(
+                    f"SpecLog row {line_number} has {len(row)} columns; "
+                    f"expected {len(header)}"
+                )
+
+            fields = [field.strip() for field in row]
+            try:
+                timestamp = datetime.fromisoformat(f"{fields[0]} {fields[1]}")
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid SpecLog timestamp on row {line_number}: "
+                    f"{fields[0]} {fields[1]}"
+                ) from exc
+
+            values = []
+            for channel, field in zip(channels, fields[2:]):
+                if field == "":
+                    values.append(_np.nan)
+                    continue
+                try:
+                    values.append(float(field))
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Invalid numeric value for channel {channel!r} "
+                        f"on row {line_number}: {field!r}"
+                    ) from exc
+
+            timestamps.append(timestamp)
+            rows.append(values)
+
+    values = _np.asarray(rows, dtype=float).reshape((-1, len(channels)))
+    time_coord = _np.asarray(timestamps, dtype="datetime64[us]")
+    channel_coord = _np.asarray(channels, dtype=str)
+    attrs = {
+        "source_file": os.path.abspath(filename),
+        "experiment_type": "SpecLog",
+    }
+    return SpinData(
+        values,
+        dims=["time", "channel"],
+        coords=[time_coord, channel_coord],
+        attrs=attrs,
+    )

--- a/spinlab/plotting/general.py
+++ b/spinlab/plotting/general.py
@@ -126,7 +126,7 @@ def fancy_plot(
 ):
     """Streamline Plot function for sldata objects
 
-    This function creates streamlined plots for NMR and EPR spectra. The type of the spectrum is detected from the attribute "experiment_type" of the sldata object. Currently the following types are implemented: nmr_spectrum, epr_spectrum, enhancements_P, and inversion_recovery. The function will automatically format the plot according to the "experiment_type" attribute.
+    This function creates streamlined plots for NMR, EPR, and SpecLog data. The type of the spectrum is detected from the attribute "experiment_type" of the sldata object. The function will automatically format the plot according to the "experiment_type" attribute.
 
     Args:
         data (SpinData): SpinData object with values to plot
@@ -160,6 +160,7 @@ def fancy_plot(
         plot(data, *args, **kwargs)
         return
 
+    tight_layout_rect = None
     _plt.grid(True, ls=":")
     _plt.title(title)
 
@@ -198,6 +199,71 @@ def fancy_plot(
 
             _plt.text(xmin * 0.95, ymax / 10, parameterString, bbox=box_style)
 
+        data.fold()
+
+    elif data.attrs["experiment_type"].lower() == "speclog":
+        exp_type = fancyplot_label + ":" + data.attrs["experiment_type"]
+        dim = kwargs.pop("dim", SpinLAB_CONFIG.get(exp_type, "dim", fallback="time"))
+        if dim not in data.dims:
+            raise ValueError(
+                f"SpecLog data does not contain the requested dimension {dim!r}"
+            )
+
+        coord = data.coords[dim]
+        data.unfold(dim)
+        plt_config_kwargs = {
+            key.lstrip("__"): val
+            for key, val in SpinLAB_CONFIG[exp_type].items()
+            if key.startswith("__")
+        }
+        plt_config_kwargs.update(kwargs)
+        plot_return = _plt.plot(coord, data.values.real, *args, **plt_config_kwargs)
+
+        ax = _plt.gca()
+        fig = _plt.gcf()
+        for key in SpinLAB_CONFIG[exp_type].keys():
+            if key.startswith("ax.") or key.startswith("fig."):
+                config_args, config_kwargs = SpinLAB_CONFIG.getargs_kwargs(
+                    exp_type, key
+                )
+                prm_key = key.lstrip("ax.").lstrip("fig.")
+                if key.startswith("ax."):
+                    getattr(ax, prm_key)(*config_args, **config_kwargs)
+                else:
+                    getattr(fig, prm_key)(*config_args, **config_kwargs)
+
+        channel_names = (
+            [str(name) for name in data.coords["channel"]]
+            if "channel" in data.dims
+            else []
+        )
+        if channel_names:
+            legend_labels = [name.replace("_", " ") for name in channel_names]
+            legend_ncol = SpinLAB_CONFIG.getint(exp_type, "legend_ncol", fallback=3)
+            fig.legend(
+                plot_return,
+                legend_labels,
+                loc=SpinLAB_CONFIG.get(exp_type, "legend_loc", fallback="lower center"),
+                bbox_to_anchor=(
+                    SpinLAB_CONFIG.getfloat(exp_type, "legend_bbox_x", fallback=0.5),
+                    SpinLAB_CONFIG.getfloat(exp_type, "legend_bbox_y", fallback=0.01),
+                ),
+                ncol=legend_ncol,
+            )
+            legend_rows = int(_np.ceil(len(channel_names) / legend_ncol))
+            legend_margin = SpinLAB_CONFIG.getfloat(
+                exp_type, "legend_margin_base", fallback=0.08
+            ) + legend_rows * SpinLAB_CONFIG.getfloat(
+                exp_type, "legend_margin_per_row", fallback=0.055
+            )
+            tight_layout_rect = (0, legend_margin, 1, 1)
+
+        if xlim != []:
+            _plt.xlim(_np.datetime64(xlim[0]), _np.datetime64(xlim[1]))
+        if title != "":
+            _plt.title(title)
+
+        fig.autofmt_xdate()
         data.fold()
 
     elif data.attrs["experiment_type"] in fancyplot_sections:
@@ -315,6 +381,6 @@ def fancy_plot(
     else:
         plot_return = plot(data, *args, **kwargs)
 
-    _plt.tight_layout()
+    _plt.tight_layout(rect=tight_layout_rect)
 
     return plot_return

--- a/unittests/data_testconfig.cfg
+++ b/unittests/data_testconfig.cfg
@@ -47,6 +47,19 @@ ax.set_title= Saturation Recovery
 __marker = o
 __fillstyle = none
 
+[FANCY_PLOT:SpecLog]
+
+dim = time
+ax.set_xlabel = Time
+ax.set_ylabel = Value
+ax.set_title = SpecLog
+legend_loc = lower center
+legend_bbox_x = 0.5
+legend_bbox_y = 0.01
+legend_ncol = 3
+legend_margin_base = 0.08
+legend_margin_per_row = 0.055
+
 [FANCY_PLOT:polarization_buildup]
 
 ax.set_xlabel= Contact Time t$_c$ [s]

--- a/unittests/test_io_speclog.py
+++ b/unittests/test_io_speclog.py
@@ -1,0 +1,249 @@
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+import spinlab as sl
+
+
+class SpecLogImportTester(unittest.TestCase):
+    def _write(self, contents, name="log_20250117.csv"):
+        directory = tempfile.TemporaryDirectory()
+        path = os.path.join(directory.name, name)
+        with open(path, "w", encoding="utf-8", newline="") as csv_file:
+            csv_file.write(contents)
+        self.addCleanup(directory.cleanup)
+        return path
+
+    def test_load_speclog(self):
+        path = self._write(
+            "Date, Time, temperature, status\n"
+            "2025-01-17, 00:00:12, +03.248, 0301\n"
+            "2025-01-17, 00:00:42, +03.224, \n"
+        )
+
+        data = sl.io.speclog.load_speclog(path)
+
+        self.assertEqual(data.dims, ["time", "channel"])
+        self.assertEqual(data.values.shape, (2, 2))
+        np.testing.assert_array_equal(data.coords["channel"], ["temperature", "status"])
+        self.assertEqual(data.coords["time"][0], np.datetime64("2025-01-17T00:00:12"))
+        self.assertEqual(data.values[0, 1], 301.0)
+        self.assertTrue(np.isnan(data.values[1, 1]))
+
+    def test_load_and_autodetect_speclog(self):
+        path = self._write("Date, Time, temperature\n2025-01-17, 00:00:12, 3.248\n")
+
+        data = sl.load(path)
+
+        self.assertEqual(data.dims, ["time", "channel"])
+        self.assertEqual(data.values[0, 0], 3.248)
+
+    def test_select_time_with_timestamp_string(self):
+        path = self._write(
+            "Date, Time, temperature\n"
+            "2025-01-17, 00:00:12, 3.248\n"
+            "2025-01-17, 00:00:42, 3.224\n"
+            "2025-01-17, 00:01:12, 3.188\n"
+        )
+        data = sl.load(path)
+
+        selected = data["time", "2025-01-17T00:00:40"]
+
+        self.assertEqual(selected.shape, (1, 1))
+        self.assertEqual(
+            selected.coords["time"][0], np.datetime64("2025-01-17T00:00:42")
+        )
+        self.assertEqual(selected.values[0, 0], 3.224)
+
+    def test_select_time_range_with_timestamp_strings(self):
+        path = self._write(
+            "Date, Time, temperature\n"
+            "2025-01-17, 00:00:12, 3.248\n"
+            "2025-01-17, 00:00:42, 3.224\n"
+            "2025-01-17, 00:01:12, 3.188\n"
+        )
+        data = sl.load(path)
+
+        selected = data[
+            "time", ("2025-01-17T00:00:12", "2025-01-17T00:01:12")
+        ]
+
+        np.testing.assert_array_equal(selected.values[:, 0], [3.248, 3.224])
+
+    def test_select_channel_with_header_string(self):
+        path = self._write(
+            "Date, Time, helium_discharge_temperature, status\n"
+            "2025-01-17, 00:00:12, 53, 0301\n"
+            "2025-01-17, 00:00:42, 54, 0302\n"
+        )
+        data = sl.load(path)
+
+        selected = data["channel", "helium_discharge_temperature"]
+
+        self.assertEqual(selected.shape, (2, 1))
+        np.testing.assert_array_equal(selected.values[:, 0], [53.0, 54.0])
+        np.testing.assert_array_equal(
+            selected.coords["channel"], ["helium_discharge_temperature"]
+        )
+
+    def test_missing_channel_name_raises_key_error(self):
+        path = self._write(
+            "Date, Time, temperature\n2025-01-17, 00:00:12, 3.248\n"
+        )
+        data = sl.load(path)
+
+        with self.assertRaisesRegex(KeyError, "missing.*channel"):
+            data["channel", "missing"]
+
+    def test_select_multiple_channels_by_name(self):
+        path = self._write(
+            "Date, Time, temperature, status, pressure\n"
+            "2025-01-17, 00:00:12, 3.248, 0301, 80\n"
+            "2025-01-17, 00:00:42, 3.224, 0302, 79\n"
+        )
+        data = sl.load(path)
+
+        selected = data["channel", ["pressure", "temperature"]]
+
+        self.assertEqual(selected.shape, (2, 2))
+        np.testing.assert_array_equal(
+            selected.coords["channel"], ["pressure", "temperature"]
+        )
+        np.testing.assert_array_equal(
+            selected.values, [[80.0, 3.248], [79.0, 3.224]]
+        )
+
+    def test_missing_name_in_multiple_channel_selection_raises_key_error(self):
+        path = self._write(
+            "Date, Time, temperature\n2025-01-17, 00:00:12, 3.248\n"
+        )
+        data = sl.load(path)
+
+        with self.assertRaisesRegex(KeyError, "missing.*channel"):
+            data["channel", ["temperature", "missing"]]
+
+    def test_load_file_list_merges_and_sorts_by_time(self):
+        later = self._write(
+            "Date, Time, temperature, status\n"
+            "2025-01-18, 00:00:12, 4.0, 0302\n",
+            name="log_20250118.csv",
+        )
+        earlier = self._write(
+            "Date, Time, status, temperature\n"
+            "2025-01-17, 00:00:42, 0301, 3.2\n"
+            "2025-01-17, 00:00:12, 0300, 3.1\n",
+            name="log_20250117.csv",
+        )
+
+        data = sl.load([later, earlier])
+
+        self.assertEqual(data.dims, ["time", "channel"])
+        self.assertEqual(data.shape, (3, 2))
+        np.testing.assert_array_equal(
+            data.coords["time"],
+            np.asarray(
+                [
+                    "2025-01-17T00:00:12",
+                    "2025-01-17T00:00:42",
+                    "2025-01-18T00:00:12",
+                ],
+                dtype="datetime64[us]",
+            ),
+        )
+        np.testing.assert_array_equal(
+            data.coords["channel"], ["temperature", "status"]
+        )
+        np.testing.assert_array_equal(
+            data.values,
+            [[3.1, 300.0], [3.2, 301.0], [4.0, 302.0]],
+        )
+        self.assertEqual(len(data.attrs["source_files"]), 2)
+
+    def test_merge_rejects_different_channels(self):
+        first = self._write(
+            "Date, Time, temperature\n2025-01-17, 00:00:12, 3.1\n",
+            name="log_first.csv",
+        )
+        second = self._write(
+            "Date, Time, pressure\n2025-01-18, 00:00:12, 80\n",
+            name="log_second.csv",
+        )
+
+        with self.assertRaisesRegex(ValueError, "channels.*do not match"):
+            sl.load([first, second], data_format="speclog")
+
+    def test_fancy_plot_uses_channel_names(self):
+        path = self._write(
+            "Date, Time, temperature, status\n"
+            "2025-01-17, 00:00:12, 3.248, 0301\n"
+            "2025-01-17, 00:00:42, 3.224, 0302\n"
+        )
+        data = sl.load(path)
+        self.addCleanup(plt.close, "all")
+
+        lines = sl.fancy_plot(data)
+
+        axes = plt.gca()
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(axes.get_xlabel(), "Time")
+        self.assertEqual(axes.get_ylabel(), "Value")
+        self.assertEqual(axes.get_title(), "SpecLog")
+        legend = plt.gcf().legends[0]
+        self.assertEqual(
+            [text.get_text() for text in legend.get_texts()],
+            ["temperature", "status"],
+        )
+        self.assertIsNone(axes.get_legend())
+        self.assertEqual(legend._loc, 8)  # lower center
+        self.assertAlmostEqual(
+            legend.get_bbox_to_anchor()._bbox.x0, 0.5
+        )
+
+    def test_fancy_plot_single_channel_uses_name_as_label(self):
+        path = self._write(
+            "Date, Time, temperature, status\n"
+            "2025-01-17, 00:00:12, 3.248, 0301\n"
+            "2025-01-17, 00:00:42, 3.224, 0302\n"
+        )
+        data = sl.load(path)["channel", "temperature"]
+        self.addCleanup(plt.close, "all")
+
+        sl.fancy_plot(data)
+
+        axes = plt.gca()
+        self.assertEqual(axes.get_ylabel(), "Value")
+        self.assertEqual(
+            [text.get_text() for text in plt.gcf().legends[0].get_texts()],
+            ["temperature"],
+        )
+
+    def test_fancy_plot_formats_channel_labels_for_display(self):
+        path = self._write(
+            "Date, Time, helium_discharge_temperature\n"
+            "2025-01-17, 00:00:12, 53\n"
+        )
+        data = sl.load(path)
+        self.addCleanup(plt.close, "all")
+
+        sl.fancy_plot(data)
+
+        self.assertEqual(
+            plt.gcf().legends[0].get_texts()[0].get_text(),
+            "helium discharge temperature",
+        )
+        self.assertEqual(
+            data.coords["channel"][0], "helium_discharge_temperature"
+        )
+
+    def test_rejects_wrong_row_width(self):
+        path = self._write("Date, Time, temperature\n2025-01-17, 00:00:12\n")
+
+        with self.assertRaisesRegex(ValueError, "row 2 has 2 columns; expected 3"):
+            sl.io.speclog.load_speclog(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- [ ] closes issue #71
- [x] tests added / passed `pytest .`
- [x] passes `black .`
- [x] what's new

This feature introduces comprehensive support for SpecLog CSV files, enabling seamless loading, advanced indexing, and specialized plotting.

**Key enhancements include:**
*   **Data Loading**: A new `spinlab.io.speclog` module is added to parse SpecLog CSVs, automatically detecting `log_*.csv` files as this format. It supports loading single files or merging multiple files, ensuring channels are aligned and data is sorted by time.
*   **Flexible Indexing**: Enhances `ABCData` indexing to interpret datetime strings and ranges for time coordinates, and exact string matches or lists of strings for channel names.
*   **Streamlined Plotting**: Integrates a dedicated `fancy_plot` configuration for SpecLog data, providing automatic time axis formatting and a clear legend derived from channel names.