### PR TITLE
Enhances Plotting and Widget Functions with Tests

### DIFF
--- a/spinlab/plotting/general.py
+++ b/spinlab/plotting/general.py
@@ -182,7 +182,7 @@ def fancy_plot(
         data.unfold(dim)
 
         plot_return = _plt.plot(coord, data.values.real, *args, **kwargs)
-        _plt.xlabel("Chemical Shift $\delta$ (ppm)")
+        _plt.xlabel(r"Chemical Shift $\delta$ (ppm)")
         _plt.ylabel("NMR Signal Intensity (a.u.)")
 
         _plt.xlim(max(coord), min(coord))

--- a/spinlab/plotting/image.py
+++ b/spinlab/plotting/image.py
@@ -57,12 +57,13 @@ def imshow(data, *args, **kwargs):  # TODO: drop unused args and kwargs
 
     if "extent" in kwargs:
         extent = kwargs["extent"]
-        kwargs.pop(extent)
+        kwargs.pop("extent")
     else:
         extent = [x_min, x_max, y_max, y_min]
 
-    _plt.imshow(
+    image = _plt.imshow(
         data.values, *args, aspect=aspect, extent=extent, origin=origin, **kwargs
     )
     _plt.xlabel(dims[1])
     _plt.ylabel(dims[0])
+    return image

--- a/spinlab/widgets/align_widget.py
+++ b/spinlab/widgets/align_widget.py
@@ -1,20 +1,25 @@
-import numpy as _np
-
 import matplotlib.pyplot as _plt
-from matplotlib.widgets import Slider, Button, RadioButtons
+import numpy as _np
+from matplotlib.widgets import Slider, Button
 
 
 def align_widget(data, dim):
     """Manually align spectra"""
 
+    if data.ndim != 2:
+        raise ValueError("align_widget requires 2D data.")
+    if dim not in data.dims:
+        raise ValueError(f"dim {dim} not in data.dims ({data.dims})")
+
     coord = data.coords[dim]
+    plot_dim = [data_dim for data_dim in data.dims if data_dim != dim][0]
     max_index = int(data.size / (coord.size**2.0))
 
     fig, ax = _plt.subplots()
     _plt.subplots_adjust(left=0.25, bottom=0.25)
     init_index = 0
     delta_index = 1
-    l = _plt.plot(data.coords["f2"], _np.real(data.values))
+    l = _plt.plot(data.coords[plot_dim], _np.real(data.values))
     ax.margins(x=0)
 
     axcolor = "lightgoldenrodyellow"
@@ -60,6 +65,13 @@ def align_widget(data, dim):
     reset_button.on_clicked(reset)
     inc_button.on_clicked(inc)
     dec_button.on_clicked(dec)
+
+    fig._widgets = {
+        "index": sindex,
+        "reset": reset_button,
+        "increment": inc_button,
+        "decrement": dec_button,
+    }
 
     _plt.show()
     manual_index = sindex.val

--- a/spinlab/widgets/phase_widget.py
+++ b/spinlab/widgets/phase_widget.py
@@ -18,6 +18,9 @@ def phase_widget(data, dim="f2"):
 
     """
 
+    if dim not in data.dims:
+        raise ValueError(f"dim {dim} not in data.dims ({data.dims})")
+
     fig, ax = plt.subplots()
 
     plt.title("Manual Phase")
@@ -30,8 +33,8 @@ def phase_widget(data, dim="f2"):
     values = values.reshape(size, -1)
     values = values[:, 0].reshape(-1, 1)
 
-    l0 = plt.plot(coord, values, alpha=0.5)
-    l = plt.plot(coord, values)
+    l0 = plt.plot(coord, values.real, alpha=0.5)
+    l = plt.plot(coord, values.real)
     ax.margins(x=0)
 
     axcolor = "lightgoldenrodyellow"
@@ -103,11 +106,25 @@ def phase_widget(data, dim="f2"):
     minus_90_button.on_clicked(minus_90_phase)
     rescale_yaxis_button.on_clicked(rescale)
 
+    fig._widgets = {
+        "phase": sphase,
+        "phase1": sphase1,
+        "reset": reset_button,
+        "plus_90": plus_90_button,
+        "minus_90": minus_90_button,
+        "rescale": rescale_yaxis_button,
+    }
+
     plt.show()
     manual_phase = sphase.val
     manual_phase1 = sphase1.val
 
-    data *= _np.exp(-1j * _const.pi * manual_phase / 180.0)
+    phase_axis = _np.exp(-1j * _const.pi * manual_phase1 * coord / 180.0)
+    phase_shape = [1 for _ in data.shape]
+    phase_shape[data.index(dim)] = coord.size
+    data *= _np.exp(-1j * _const.pi * manual_phase / 180.0) * phase_axis.reshape(
+        phase_shape
+    )
 
     proc_attr_name = "manualphase"
     proc_parameters = {"phase": manual_phase, "phase1": manual_phase1}

--- a/unittests/test_plotting_general.py
+++ b/unittests/test_plotting_general.py
@@ -1,0 +1,85 @@
+import unittest
+import warnings
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+import matplotlib.pyplot as plt
+import numpy as np
+import spinlab as sl
+from numpy.testing import assert_array_equal
+
+
+class sl_plotting_general_tester(unittest.TestCase):
+    def setUp(self):
+        plt.close("all")
+        self.x = np.linspace(0.0, 1.0, 5)
+        self.scan = np.array([0, 1, 2])
+        self.data_1d = sl.SpinData(self.x**2, ["x"], [self.x])
+        self.data_2d = sl.SpinData(
+            self.x.reshape(-1, 1) + self.scan.reshape(1, -1),
+            ["x", "scan"],
+            [self.x, self.scan],
+        )
+
+    def tearDown(self):
+        plt.close("all")
+
+    def test_plot_1d_sets_xlabel_and_returns_lines(self):
+        lines = sl.plot(self.data_1d)
+
+        self.assertEqual(len(lines), 1)
+        assert_array_equal(lines[0].get_xdata(), self.x)
+        assert_array_equal(lines[0].get_ydata(), self.data_1d.values)
+        self.assertEqual(plt.gca().get_xlabel(), "x")
+
+    def test_plot_2d_unfolds_selected_dim_and_restores_input(self):
+        original_dims = self.data_2d.dims.copy()
+        original_values = self.data_2d.values.copy()
+
+        lines = sl.plot(self.data_2d, dim="x")
+
+        self.assertEqual(len(lines), self.scan.size)
+        assert_array_equal(lines[0].get_xdata(), self.x)
+        assert_array_equal(lines[1].get_ydata(), self.data_2d.values[:, 1])
+        self.assertEqual(self.data_2d.dims, original_dims)
+        assert_array_equal(self.data_2d.values, original_values)
+
+    def test_plot_forwards_semilogy_keyword(self):
+        data = sl.SpinData(np.exp(self.x), ["x"], [self.x])
+
+        out = sl.plot(data, semilogy=True)
+
+        self.assertEqual(len(out), 1)
+        self.assertEqual(plt.gca().get_yscale(), "log")
+
+    def test_fancy_plot_missing_experiment_type_falls_back_to_plot(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            out = sl.fancy_plot(self.data_1d)
+
+        self.assertIsNone(out)
+        self.assertEqual(len(plt.gca().lines), 1)
+        self.assertTrue(
+            any("experiment_type not defined" in str(w.message) for w in caught)
+        )
+
+    def test_fancy_plot_nmr_spectrum_sets_labels_and_reverses_xaxis(self):
+        data = sl.SpinData(
+            self.x,
+            ["ppm"],
+            [self.x],
+            attrs={"experiment_type": "nmr_spectrum", "nmr_frequency": 400e6},
+        )
+
+        lines = sl.fancy_plot(data)
+
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(plt.gca().get_xlabel(), "Chemical Shift $\\delta$ (ppm)")
+        self.assertEqual(plt.gca().get_ylabel(), "NMR Signal Intensity (a.u.)")
+        xlim = plt.gca().get_xlim()
+        self.assertGreater(xlim[0], xlim[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unittests/test_plotting_image.py
+++ b/unittests/test_plotting_image.py
@@ -1,0 +1,47 @@
+import unittest
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+import matplotlib.pyplot as plt
+import numpy as np
+import spinlab as sl
+from matplotlib.image import AxesImage
+from numpy.testing import assert_allclose
+
+
+class sl_plotting_image_tester(unittest.TestCase):
+    def setUp(self):
+        plt.close("all")
+        self.x = np.linspace(0.0, 1.0, 5)
+        self.scan = np.array([0, 1, 2])
+        self.data = sl.SpinData(
+            self.x.reshape(-1, 1) + self.scan.reshape(1, -1),
+            ["x", "scan"],
+            [self.x, self.scan],
+        )
+
+    def tearDown(self):
+        plt.close("all")
+
+    def test_imshow_returns_image_and_sets_default_extent(self):
+        image = sl.imshow(self.data)
+
+        self.assertIsInstance(image, AxesImage)
+        self.assertEqual(plt.gca().get_xlabel(), "scan")
+        self.assertEqual(plt.gca().get_ylabel(), "x")
+        assert_allclose(image.get_extent(), [0, 2, 0.0, 1.0])
+        self.assertEqual(image.origin, "lower")
+
+    def test_imshow_accepts_extent_origin_and_aspect(self):
+        extent = [10.0, 20.0, 30.0, 40.0]
+
+        image = sl.imshow(self.data, extent=extent, origin="upper", aspect="equal")
+
+        assert_allclose(image.get_extent(), extent)
+        self.assertEqual(image.origin, "upper")
+        self.assertEqual(plt.gca().get_aspect(), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unittests/test_plotting_slice_viewer.py
+++ b/unittests/test_plotting_slice_viewer.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest.mock import patch
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+import matplotlib.pyplot as plt
+import numpy as np
+import spinlab as sl
+from numpy.testing import assert_allclose
+
+
+class sl_plotting_slice_viewer_tester(unittest.TestCase):
+    def setUp(self):
+        plt.close("all")
+        self.x = np.linspace(0.0, 1.0, 5)
+        self.scan = np.array([0, 1, 2])
+        self.data = sl.SpinData(
+            self.x.reshape(-1, 1) + self.scan.reshape(1, -1),
+            ["x", "scan"],
+            [self.x, self.scan],
+        )
+
+    def tearDown(self):
+        plt.close("all")
+
+    def test_slice_viewer_real_data_returns_figure_and_updates_slider(self):
+        with patch("spinlab.plotting.slice_viewer._plt.show"):
+            fig = sl.slice_viewer(self.data, scroll_dim="scan")
+
+        self.assertEqual(len(fig.axes[0].lines), 1)
+        self.assertEqual(fig.axes[0].get_xlabel(), "x")
+        self.assertEqual(fig.axes[0].get_ylabel(), "Intensity")
+        slider = fig._widgets[0]
+        slider.set_val(2)
+        assert_allclose(fig.axes[0].lines[0].get_ydata(), self.data.values[:, 2])
+        self.assertIn("scan = 2", fig.axes[0].get_title())
+
+    def test_slice_viewer_complex_data_plots_real_and_imag(self):
+        values = self.data.values + 1j * (2.0 * self.data.values)
+        data = sl.SpinData(values, ["x", "scan"], [self.x, self.scan])
+
+        with patch("spinlab.plotting.slice_viewer._plt.show"):
+            fig = sl.slice_viewer(data, scroll_dim="scan")
+
+        self.assertEqual(len(fig.axes[0].lines), 2)
+        slider = fig._widgets[0]
+        slider.set_val(1)
+        assert_allclose(fig.axes[0].lines[0].get_ydata(), values[:, 1].real)
+        assert_allclose(fig.axes[0].lines[1].get_ydata(), values[:, 1].imag)
+
+    def test_slice_viewer_requires_2d_data(self):
+        data_1d = sl.SpinData(self.x, ["x"], [self.x])
+
+        with self.assertRaises(ValueError):
+            sl.slice_viewer(data_1d)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unittests/test_plotting_stack_plot.py
+++ b/unittests/test_plotting_stack_plot.py
@@ -1,0 +1,47 @@
+import unittest
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+import matplotlib.pyplot as plt
+import numpy as np
+import spinlab as sl
+from numpy.testing import assert_allclose, assert_array_equal
+
+
+class sl_plotting_stack_plot_tester(unittest.TestCase):
+    def setUp(self):
+        plt.close("all")
+        self.x = np.linspace(0.0, 1.0, 5)
+        self.scan = np.array([0, 1, 2])
+        self.data = sl.SpinData(
+            self.x.reshape(-1, 1) + self.scan.reshape(1, -1),
+            ["x", "scan"],
+            [self.x, self.scan],
+        )
+
+    def tearDown(self):
+        plt.close("all")
+
+    def test_stack_offsets_each_column(self):
+        sl.stack(self.data, offset=10.0)
+
+        lines = plt.gca().lines
+        self.assertEqual(len(lines), self.scan.size)
+        assert_array_equal(lines[0].get_xdata(), self.x)
+        assert_allclose(lines[0].get_ydata(), self.data.values[:, 0])
+        assert_allclose(lines[1].get_ydata(), self.data.values[:, 1] + 10.0)
+        assert_allclose(lines[2].get_ydata(), self.data.values[:, 2] + 20.0)
+
+    def test_waterfall_offsets_lines_and_adds_fills(self):
+        sl.waterfall(self.data, dx=0.1, dy=2.0)
+
+        ax = plt.gca()
+        self.assertEqual(len(ax.lines), self.scan.size)
+        self.assertEqual(len(ax.collections), self.scan.size)
+        assert_allclose(ax.lines[1].get_xdata(), self.x + 0.1)
+        assert_allclose(ax.lines[1].get_ydata(), self.data.values[:, 1] + 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unittests/test_widgets_align_widget.py
+++ b/unittests/test_widgets_align_widget.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import patch
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+import matplotlib.pyplot as plt
+import numpy as np
+import spinlab as sl
+from numpy.testing import assert_array_equal
+
+
+class sl_widgets_align_widget_tester(unittest.TestCase):
+    def setUp(self):
+        plt.close("all")
+        self.x = np.arange(5)
+        self.scan = np.arange(3)
+        self.values = np.vstack(
+            [
+                np.arange(5),
+                np.arange(10, 15),
+                np.arange(20, 25),
+            ]
+        ).T
+        self.data = sl.SpinData(self.values, ["x", "scan"], [self.x, self.scan])
+
+    def tearDown(self):
+        plt.close("all")
+
+    def test_align_widget_uses_slider_value_to_roll_each_trace(self):
+        original_values = self.data.values.copy()
+
+        def set_manual_index():
+            plt.gcf()._widgets["index"].set_val(1)
+
+        with patch("spinlab.widgets.align_widget._plt.show", side_effect=set_manual_index):
+            out = sl.align_widget(self.data, dim="scan")
+
+        expected = original_values.copy()
+        for ix in range(self.scan.size):
+            expected[:, ix] = np.roll(original_values[:, ix], ix)
+
+        self.assertIs(out, self.data)
+        assert_array_equal(out.values, expected)
+        self.assertEqual(out.proc_attrs[-1][0], "manualalign")
+        self.assertEqual(out.proc_attrs[-1][1], {"dim": "scan"})
+
+    def test_align_widget_exposes_slider_and_buttons_on_figure(self):
+        captured = {}
+
+        def capture_widgets():
+            captured.update(plt.gcf()._widgets)
+
+        with patch("spinlab.widgets.align_widget._plt.show", side_effect=capture_widgets):
+            sl.align_widget(self.data.copy(), dim="scan")
+
+        self.assertIn("index", captured)
+        self.assertIn("reset", captured)
+        self.assertIn("increment", captured)
+        self.assertIn("decrement", captured)
+
+    def test_align_widget_invalid_inputs_raise_value_error(self):
+        data_1d = sl.SpinData(self.x, ["x"], [self.x])
+
+        with self.assertRaises(ValueError):
+            sl.align_widget(data_1d, dim="x")
+        with self.assertRaises(ValueError):
+            sl.align_widget(self.data, dim="missing")
+
+    def test_align_widget_is_exported_at_top_level(self):
+        from spinlab.widgets.align_widget import align_widget
+
+        self.assertIs(sl.align_widget, align_widget)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unittests/test_widgets_phase_widget.py
+++ b/unittests/test_widgets_phase_widget.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest.mock import patch
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+import matplotlib.pyplot as plt
+import numpy as np
+import spinlab as sl
+from numpy.testing import assert_allclose
+
+
+class sl_widgets_phase_widget_tester(unittest.TestCase):
+    def setUp(self):
+        plt.close("all")
+        self.f2 = np.array([-1.0, 0.0, 1.0])
+        self.values = np.array([1.0 + 1.0j, 2.0 + 0.5j, 3.0 - 1.0j])
+        self.data = sl.SpinData(self.values.copy(), ["f2"], [self.f2])
+
+    def tearDown(self):
+        plt.close("all")
+
+    def test_phase_widget_applies_zero_and_first_order_phase(self):
+        def set_manual_phase():
+            widgets = plt.gcf()._widgets
+            widgets["phase"].set_val(90)
+            widgets["phase1"].set_val(10)
+
+        with patch("spinlab.widgets.phase_widget.plt.show", side_effect=set_manual_phase):
+            out = sl.phase_widget(self.data, dim="f2")
+
+        expected = self.values * np.exp(-1j * np.pi * 90 / 180.0)
+        expected *= np.exp(-1j * np.pi * 10 * self.f2 / 180.0)
+
+        assert_allclose(out.values, expected)
+        assert_allclose(self.data.values, self.values)
+        self.assertEqual(out.attrs["phase0"], 90)
+        self.assertEqual(out.attrs["phase1"], 10)
+        self.assertEqual(out.proc_attrs[-1][0], "manualphase")
+        self.assertEqual(out.proc_attrs[-1][1], {"phase": 90, "phase1": 10})
+
+    def test_phase_widget_broadcasts_first_order_phase_on_selected_dim(self):
+        scan = np.array([0, 1])
+        values = np.column_stack([self.values, 2.0 * self.values])
+        data = sl.SpinData(values.copy(), ["f2", "scan"], [self.f2, scan])
+
+        def set_manual_phase():
+            widgets = plt.gcf()._widgets
+            widgets["phase"].set_val(0)
+            widgets["phase1"].set_val(20)
+
+        with patch("spinlab.widgets.phase_widget.plt.show", side_effect=set_manual_phase):
+            out = sl.phase_widget(data, dim="f2")
+
+        expected = values * np.exp(
+            -1j * np.pi * 20 * self.f2.reshape(-1, 1) / 180.0
+        )
+        assert_allclose(out.values, expected)
+
+    def test_phase_widget_exposes_sliders_and_buttons_on_figure(self):
+        captured = {}
+
+        def capture_widgets():
+            captured.update(plt.gcf()._widgets)
+
+        with patch("spinlab.widgets.phase_widget.plt.show", side_effect=capture_widgets):
+            sl.phase_widget(self.data.copy(), dim="f2")
+
+        for name in ["phase", "phase1", "reset", "plus_90", "minus_90", "rescale"]:
+            with self.subTest(name=name):
+                self.assertIn(name, captured)
+
+    def test_phase_widget_invalid_dim_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            sl.phase_widget(self.data, dim="missing")
+
+    def test_phase_widget_is_exported_at_top_level(self):
+        from spinlab.widgets.phase_widget import phase_widget
+
+        self.assertIs(sl.phase_widget, phase_widget)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- [x] tests added / passed `pytest .`
- [x] passes `black .`
- [x] passes `git diff upstream/develop -u -- "*.py" | flake8 --diff`
- [x] what's new

This pull request significantly enhances the `spinlab` plotting and interactive widget functionalities, while also introducing extensive unit tests to ensure robustness and correctness.

Key changes include:

*   **Plotting Functions**:
    *   Corrects the LaTeX rendering of chemical shift labels in `fancy_plot`.
    *   Fixes a bug in `imshow` where the `extent` keyword argument was not properly popped, and now returns the `AxesImage` object for greater utility.
    *   Adds comprehensive unit tests for `plot`, `fancy_plot`, `imshow`, `slice_viewer`, `stack`, and `waterfall` to validate their behavior.
*   **Interactive Widgets**:
    *   `align_widget` and `phase_widget` now include robust input validation for data dimensionality and specified dimensions, preventing common errors.
    *   `align_widget` features more generic plotting logic, adapting to different dimension names.
    *   `phase_widget` implements a more accurate first-order phase correction that correctly broadcasts across the target dimension.
    *   Both widgets expose their underlying `matplotlib` slider and button objects through `fig._widgets`, which facilitates programmatic interaction and testing.
    *   Adds dedicated unit tests for `align_widget` and `phase_widget` to cover their functionality, validation, and interaction.

This update improves the reliability and maintainability of the plotting and widget components, making them more resilient to misuse and easier to extend.